### PR TITLE
HOTFIX check msg length on "for-claims" deposits

### DIFF
--- a/contracts/meta-vote-contract/src/deposit.rs
+++ b/contracts/meta-vote-contract/src/deposit.rs
@@ -18,7 +18,7 @@ impl FungibleTokenReceiver for MetaVoteContract {
         let amount = amount.0;
 
         // deposit for-claims, msg == "for-claims" means META to be later distributed to voters
-        if &msg[..11] == "for-claims:" {
+        if msg.len() >= 11 && &msg[..11] == "for-claims:" {
             self.meta_to_distribute += amount;
             match serde_json::from_str(&msg[11..]) {
                 Ok(info) => self.distribute_for_claims(amount, &info),


### PR DESCRIPTION
ft_on_transfer for locking META is failing due to a out of bounds for the 'msg' params. 
Added a pre check of the length.

Error and failing txs reported: 
  "error": "Smart contract panicked: panicked at 'byte index 11 is out of bounds of `90`', meta-vote-contract/src/deposit.rs:21:13"
https://nearblocks.io/txns/8FTHL1uz37x7megCDL5FDHWtwtn4yGdhX9ZyQzVPXMdX
https://explorer.mainnet.near.org/transactions/D38Je4qVWd9QGeKU9dYJRZLzUAm8TzDpAh2YyUq1x46t
https://explorer.near.org/transactions/BdkrvXjvomszaQQfm2fNYb88V9QYYgA6w8jm8YNNxRZw