### PR TITLE
fix: include delegated VP in get_mpip_voting_power calculation

### DIFF
--- a/meta-vote-contract/src/view.rs
+++ b/meta-vote-contract/src/view.rs
@@ -1,4 +1,3 @@
-use crate::internal::DELEGATED_CONTRACT_CODE;
 use crate::types::*;
 use crate::{voter::VoterJSON, MetaVoteContract, MetaVoteContractExt, StorageKey};
 use near_sdk::{
@@ -186,13 +185,18 @@ impl MetaVoteContract {
     }
 
     /// MPIP voting power: returns the voter's available voting power for MPIPs.
-    /// This is the voter's self voting power minus any voting power they have delegated to others.
-    /// If a voter has delegated only 30% of their VP, they can still use the remaining 70% to vote on MPIPs.
+    /// This includes the voter's self voting power, plus any delegated voting power received from others,
+    /// minus any voting power they have delegated away to others.
+    /// Note: delegates cannot delegate away their VP, so either internal_get_delegated_vp or delegated_away_vp will be zero.
     pub fn get_mpip_voting_power(&self, voter_id: VoterId) -> U128String {
         let voter = self.internal_get_voter(&voter_id);
         let self_vp = voter.sum_locked_vp();
+        let delegated_vp = self.internal_get_delegated_vp(&voter_id);
         let delegated_away_vp = voter.sum_delegated_away_vp();
-        self_vp.saturating_sub(delegated_away_vp).into()
+        self_vp
+            .saturating_add(delegated_vp)
+            .saturating_sub(delegated_away_vp)
+            .into()
     }
 
     /// self-voting power, does not include delegated voting power


### PR DESCRIPTION
Updates get_mpip_voting_power to correctly include delegated voting power received from others. The function now calculates: sum_locked_vp() + internal_get_delegated_vp() - delegated_away_vp

Previously only considered self VP minus delegated away VP, which excluded voting power received from other voters via delegation.